### PR TITLE
Fix GraphQL queries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,5 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+.DS_Store
+.vscode/


### PR DESCRIPTION
The GraphQL queries were broken for every stream except Accounts and Contacts

The errors were being hidden by each stream's individual Parse_response function, which I've replaced with a `records_jsonpath` field which dictates where in the response the iterable data can be found

The RevenueMovements stream is still not working